### PR TITLE
Test: use Bypass for remote context test

### DIFF
--- a/test/fixtures/litepub-0.1.jsonld
+++ b/test/fixtures/litepub-0.1.jsonld
@@ -1,0 +1,41 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1",
+        {
+            "Emoji": "toot:Emoji",
+            "Hashtag": "as:Hashtag",
+            "PropertyValue": "schema:PropertyValue",
+            "atomUri": "ostatus:atomUri",
+            "conversation": {
+                "@id": "ostatus:conversation",
+                "@type": "@id"
+            },
+            "discoverable": "toot:discoverable",
+            "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
+            "capabilities": "litepub:capabilities",
+            "ostatus": "http://ostatus.org#",
+            "schema": "http://schema.org#",
+            "toot": "http://joinmastodon.org/ns#",
+            "value": "schema:value",
+            "sensitive": "as:sensitive",
+            "litepub": "http://litepub.social/ns#",
+            "invisible": "litepub:invisible",
+            "directMessage": "litepub:directMessage",
+            "listMessage": {
+                "@id": "litepub:listMessage",
+                "@type": "@id"
+            },
+            "oauthRegistrationEndpoint": {
+                "@id": "litepub:oauthRegistrationEndpoint",
+                "@type": "@id"
+            },
+            "EmojiReact": "litepub:EmojiReact",
+            "ChatMessage": "litepub:ChatMessage",
+            "alsoKnownAs": {
+                "@id": "as:alsoKnownAs",
+                "@type": "@id"
+            }
+        }
+    ]
+}

--- a/test/unit/context_test.exs
+++ b/test/unit/context_test.exs
@@ -152,7 +152,16 @@ defmodule JSON.LD.ContextTest do
 
   describe "remote contexts" do
     test "when the remote context is a list" do
-      assert context = JSON.LD.context("https://dev.poast.org/schemas/litepub-0.1.jsonld")
+      bypass = Bypass.open()
+
+      Bypass.expect(bypass, fn conn ->
+        assert "GET" == conn.method
+        assert "/litepub-0.1.jsonld" == conn.request_path
+        context = File.read!("test/fixtures/litepub-0.1.jsonld")
+        Plug.Conn.resp(conn, 200, context)
+      end)
+
+      assert context = JSON.LD.context("http://localhost:#{bypass.port}/litepub-0.1.jsonld")
 
       assert %{
                "Emoji" => "http://joinmastodon.org/ns#Emoji",


### PR DESCRIPTION
Thank you for fixing my problem in #7.

That URL will likely not stay alive, so I wanted to make sure tests won't fail if it goes offline.