### PR TITLE
Support Link header when fetching remote contexts

### DIFF
--- a/lib/json/ld/document_loader/default.ex
+++ b/lib/json/ld/document_loader/default.ex
@@ -19,8 +19,58 @@ defmodule JSON.LD.DocumentLoader.Default do
   @spec http_get(String.t()) ::
           {:ok, HTTPoison.Response.t() | HTTPoison.AsyncResponse.t()} | {:error, any}
   defp http_get(url) do
-    HTTPoison.get(url, [accept: "application/ld+json"], follow_redirect: true)
+    with {:ok, response} <-
+           HTTPoison.get(url, [accept: "application/ld+json"], follow_redirect: true) do
+      case url_from_link_header(response) do
+        nil ->
+          {:ok, response}
+
+        url ->
+          http_get(url)
+      end
+    end
   rescue
     e -> {:error, "HTTPoison failed: #{inspect(e)}"}
+  end
+
+  @spec url_from_link_header(HTTPoison.Response.t()) :: String.t() | nil
+  defp url_from_link_header(response) do
+    response.headers
+    |> Enum.find(fn {name, _} -> name == "Link" end)
+    |> case do
+      nil ->
+        nil
+
+      {"Link", content} ->
+        with {url, props} <- parse_link_header(content) do
+          if match?(%{"rel" => "alternate", "type" => "application/ld+json"}, props) do
+            if String.starts_with?(url, "http") do
+              url
+            else
+              # Relative path
+              response.request.url
+              |> URI.parse()
+              |> Map.put(:path, url)
+              |> URI.to_string()
+            end
+          end
+        end
+    end
+  end
+
+  @spec parse_link_header(String.t()) :: {String.t(), map()} | nil
+  defp parse_link_header(content) do
+    [first | prop_strings] = String.split(content, ~r/\s*;\s*/)
+
+    with [_, url] <- Regex.run(~r/\A<([^>]+)>\Z/, first) do
+      props =
+        Map.new(prop_strings, fn prop_string ->
+          [_, key, value] = Regex.run(~r/\A([^=]+)=\"([^\"]+)\"\Z/, prop_string)
+
+          {key, value}
+        end)
+
+      {url, props}
+    end
   end
 end

--- a/test/unit/document_loader/default_test.exs
+++ b/test/unit/document_loader/default_test.exs
@@ -87,6 +87,136 @@ defmodule JSON.LD.DocumentLoader.DefaultTest do
     assert JSON.LD.expand(local) == JSON.LD.expand(remote)
   end
 
+  test "loads remote context (with Link header, absolute URL)", %{local: local} do
+    bypass1 = Bypass.open(port: 44887)
+    bypass2 = Bypass.open(port: 44888)
+
+    Bypass.expect(bypass1, fn conn ->
+      assert "GET" == conn.method
+      assert "/test1-context" == conn.request_path
+
+      conn
+      |> Plug.Conn.put_resp_header("Content-Type", "text/html")
+      |> Plug.Conn.put_resp_header(
+        "Link",
+        "<http://localhost:#{bypass2.port}/test2-context>; rel=\"alternate\"; type=\"application/ld+json\""
+      )
+      |> Plug.Conn.resp(200, "<html>Not here!</html>")
+    end)
+
+    Bypass.expect(bypass2, fn conn ->
+      assert "GET" == conn.method
+      assert "/test2-context" == conn.request_path
+
+      context = %{
+        "@context" => %{
+          "homepage" => %{"@id" => "http://xmlns.com/foaf/0.1/homepage", "@type" => "@id"},
+          "name" => "http://xmlns.com/foaf/0.1/name"
+        }
+      }
+
+      Plug.Conn.resp(conn, 200, Jason.encode!(context))
+    end)
+
+    remote =
+      Jason.decode!("""
+        {
+          "@context": "http://localhost:#{bypass1.port}/test1-context",
+          "name": "Manu Sporny",
+          "homepage": "http://manu.sporny.org/"
+        }
+      """)
+
+    assert JSON.LD.expand(local) == JSON.LD.expand(remote)
+  end
+
+  test "loads remote context (with Link header, relative path)", %{local: local} do
+    bypass = Bypass.open(port: 44887)
+
+    Bypass.expect(bypass, fn conn ->
+      case conn.request_path do
+        "/test1-context" ->
+          assert "GET" == conn.method
+
+          conn
+          |> Plug.Conn.put_resp_header("Content-Type", "text/html")
+          |> Plug.Conn.put_resp_header(
+            "Link",
+            "</test2-context>; rel=\"alternate\"; type=\"application/ld+json\""
+          )
+          |> Plug.Conn.resp(200, "<html>Not here!</html>")
+
+        "/test2-context" ->
+          assert "GET" == conn.method
+
+          context = %{
+            "@context" => %{
+              "homepage" => %{"@id" => "http://xmlns.com/foaf/0.1/homepage", "@type" => "@id"},
+              "name" => "http://xmlns.com/foaf/0.1/name"
+            }
+          }
+
+          Plug.Conn.resp(conn, 200, Jason.encode!(context))
+
+        other ->
+          raise "Unexpected request: #{inspect(other)}"
+      end
+    end)
+
+    remote =
+      Jason.decode!("""
+        {
+          "@context": "http://localhost:#{bypass.port}/test1-context",
+          "name": "Manu Sporny",
+          "homepage": "http://manu.sporny.org/"
+        }
+      """)
+
+    assert JSON.LD.expand(local) == JSON.LD.expand(remote)
+  end
+
+  test "loads remote context (invalid Link headers)", %{local: local} do
+    # Should ignore the invalid Link headers in all of these cases
+
+    bypass1 = Bypass.open(port: 44887)
+    bypass2 = Bypass.open(port: 44888)
+
+    [
+      "<http://localhost:#{bypass2.port}/test2-context>; rel=\"alternate\"; type=\"text/html\"",
+      "<http://localhost:#{bypass2.port}/test2-context>; rel=\"unrecognized\"; type=\"application/ld+json\"",
+      "MALFORMED"
+    ]
+    |> Enum.each(fn link_header_content ->
+      Bypass.expect(bypass1, fn conn ->
+        assert "GET" == conn.method
+        assert "/test1-context" == conn.request_path
+
+        context = %{
+          "@context" => %{
+            "homepage" => %{"@id" => "http://xmlns.com/foaf/0.1/homepage", "@type" => "@id"},
+            "name" => "http://xmlns.com/foaf/0.1/name"
+          }
+        }
+
+        conn
+        |> Plug.Conn.put_resp_header("Content-Type", "text/html")
+        |> Plug.Conn.put_resp_header("Link", link_header_content)
+        |> Plug.Conn.resp(200, Jason.encode!(context))
+      end)
+
+      remote =
+        Jason.decode!("""
+          {
+            "@context": "http://localhost:#{bypass1.port}/test1-context",
+            "name": "Manu Sporny",
+            "homepage": "http://manu.sporny.org/"
+          }
+        """)
+
+      assert JSON.LD.expand(local) == JSON.LD.expand(remote)
+    end)
+  end
+
   test "loads remote context referring to other remote contexts", %{local: local} do
     bypass1 = Bypass.open(port: 44887)
     bypass2 = Bypass.open(port: 44888)


### PR DESCRIPTION
I referenced [this bit](https://www.w3.org/TR/json-ld11-api/#loaddocumentcallback) of the documentation (thanks @gkellogg in [this comment](https://github.com/rdf-elixir/jsonld-ex/issues/9#issuecomment-1368093014)).  The most relevant being part 5 (quoted below).  I haven't implemented all of it, but started with the basic case that would fix the issue.  I'll start playing around with more fully supporting the spec.

One question, though: that document is for JSON-LD 1.1, and as far as I can see, this library doesn't support beyond 1.0 yet.  I'm not sure if the `Link` header is a 1.0 thing, but I also wasn't able to get *any* JSON-LD data from various webpages to work because of this issue, so 🤷 

"If the retrieved resource's [Content-Type](https://tools.ietf.org/html/rfc2045#section-5) is `application/json` or any media type with a `+json` suffix as defined in [[RFC6839](https://www.w3.org/TR/json-ld11-api/#bib-rfc6839)] except `application/ld+json`, and the response has an HTTP Link Header [[RFC8288](https://www.w3.org/TR/json-ld11-api/#bib-rfc8288)] using the http://www.w3.org/ns/json-ld#context link relation, set contextUrl to the associated `href`."

"If multiple HTTP Link Headers using the http://www.w3.org/ns/json-ld#context link relation are found, the promise is rejected with a [JsonLdError](https://www.w3.org/TR/json-ld11-api/#dom-jsonlderror) whose [code](https://www.w3.org/TR/json-ld11-api/#dom-jsonlderror-code) is set to [multiple context link headers](https://www.w3.org/TR/json-ld11-api/#dom-jsonlderrorcode-multiple-context-link-headers) and processing is terminated."

"Processors MAY transform document to the [internal representation](https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation)."

"NOTE: The HTTP Link Header is ignored for documents served as application/ld+json, text/html, or application/xhtml+xml."